### PR TITLE
fix: add missing pause between parsing cycles

### DIFF
--- a/parser_cls.py
+++ b/parser_cls.py
@@ -362,6 +362,8 @@ if __name__ == "__main__":
             config = load_avito_config("config.toml")
             parser = AvitoParse(config)
             parser.parse()
+            logger.info(f"Парсинг завершен. Пауза {config.pause_general} сек")
+            time.sleep(config.pause_general)
         except Exception as err:
             logger.error(f"Произошла ошибка {err}")
             time.sleep(30)


### PR DESCRIPTION
- Added time.sleep(config.pause_general) in main loop
- Fixes continuous parsing without pause
- Resolves issue where pause_general config is ignored

- Issue link - https://github.com/Duff89/parser_avito/issues/134#issue-3306561512