### PR TITLE
Фикс для ошибки "Не удалось получить HTML"

### DIFF
--- a/parser_cls.py
+++ b/parser_cls.py
@@ -168,7 +168,8 @@ class AvitoParse:
                 if DEBUG_MODE:
                     html_code = open("december.txt", "r", encoding="utf-8").read()
                 else:
-                    html_code = self.fetch_data(url=url, retries=self.config.max_count_of_retry)
+                    client = AvitoParse(self.config)
+                    html_code = client.fetch_data(url=url)
 
                 if not html_code:
                     logger.warning(


### PR DESCRIPTION
Ошибка "Не удалось получить HTML" иногда возникает при использовании парсера без прокси, а именно при пересоздании докер-контейнера после того как парсер начал сыпать 429. Использование Playwright для получения html_code в комбинации с правильными куками решает эту проблему.