### PR TITLE
fix: fall back to multipart image upload when Telegram rejects photo URL with 400

### DIFF
--- a/integrations/notifications/telegram.py
+++ b/integrations/notifications/telegram.py
@@ -1,4 +1,5 @@
 import requests
+from loguru import logger
 
 from integrations.notifications.base import Notifier
 from integrations.notifications.transport import send_with_retries
@@ -22,7 +23,6 @@ class TelegramNotifier(Notifier):
         }
         return None
 
-
     def notify_message(self, message: str):
         def _send():
             return requests.post(
@@ -38,11 +38,55 @@ class TelegramNotifier(Notifier):
 
         send_with_retries(_send)
 
+    def _send_text_fallback(self, message: str) -> None:
+        def _send():
+            return requests.post(
+                f"https://api.telegram.org/bot{self.bot_token}/sendMessage",
+                json={
+                    "chat_id": self.chat_id,
+                    "text": message,
+                    "parse_mode": "MarkdownV2",
+                    "disable_web_page_preview": True,
+                },
+                proxies=self.proxy,
+                timeout=10,
+            )
+
+        send_with_retries(_send)
+
+    def _send_photo_bytes(self, image_url: str, message: str) -> bool:
+        """Download the image locally and re-upload to Telegram as multipart.
+
+        Returns True on success, False if the image could not be downloaded.
+        """
+        try:
+            img_resp = requests.get(image_url, proxies=self.proxy, timeout=15)
+            img_resp.raise_for_status()
+            image_bytes = img_resp.content
+        except requests.RequestException as e:
+            logger.warning(f"[notify] could not download image for multipart upload: {e}")
+            return False
+
+        def _send():
+            return requests.post(
+                f"https://api.telegram.org/bot{self.bot_token}/sendPhoto",
+                data={
+                    "chat_id": self.chat_id,
+                    "caption": message,
+                    "parse_mode": "MarkdownV2",
+                },
+                files={"photo": ("photo.jpg", image_bytes, "image/jpeg")},
+                proxies=self.proxy,
+                timeout=30,
+            )
+
+        send_with_retries(_send)
+        return True
+
     def notify_ad(self, ad: Item):
         message = self.format(ad)
 
         def _send():
-            # если включен only_text — отправляем без картинки
             if self.only_text:
                 return requests.post(
                     f"https://api.telegram.org/bot{self.bot_token}/sendMessage",
@@ -56,7 +100,6 @@ class TelegramNotifier(Notifier):
                     timeout=10,
                 )
 
-            # иначе отправляем с фото
             return requests.post(
                 f"https://api.telegram.org/bot{self.bot_token}/sendPhoto",
                 json={
@@ -70,7 +113,20 @@ class TelegramNotifier(Notifier):
                 timeout=10,
             )
 
-        send_with_retries(_send)
+        try:
+            send_with_retries(_send)
+        except requests.HTTPError as e:
+            resp = e.response
+            if not self.only_text and resp is not None and resp.status_code == 400:
+                image_url = get_first_image(ad=ad)
+                if image_url:
+                    logger.info("[notify] sendPhoto URL rejected (400), retrying with image bytes")
+                    uploaded = self._send_photo_bytes(image_url=image_url, message=message)
+                    if not uploaded:
+                        logger.warning("[notify] multipart upload also failed, falling back to text-only")
+                        self._send_text_fallback(message=message)
+                    return
+            raise
 
     def notify(self, ad: Item = None, message: str = None):
         if ad:

--- a/integrations/notifications/transport.py
+++ b/integrations/notifications/transport.py
@@ -34,6 +34,26 @@ def send_with_retries(
             response.raise_for_status()
             return response
 
+        except requests.HTTPError as e:
+            resp = e.response
+            # 4xx errors other than 429 are client errors — retrying won't help
+            if resp is not None and 400 <= resp.status_code < 500 and resp.status_code not in RETRY_STATUS_CODES:
+                logger.error(
+                    f"[notify] non-retryable client error {resp.status_code}, aborting"
+                )
+                raise
+
+            logger.warning(
+                f"[notify retry] attempt {attempt}/{retries}: {e}"
+            )
+
+            if attempt >= retries:
+                logger.error("[notify retry] retries exhausted")
+                raise
+
+            sleep_time = delay * (backoff ** (attempt - 1))
+            time.sleep(sleep_time)
+
         except requests.RequestException as e:
             logger.warning(
                 f"[notify retry] attempt {attempt}/{retries}: {e}"


### PR DESCRIPTION
Fixes #290

When Avito image URLs are passed to Telegram's `sendPhoto` endpoint, Telegram's servers can no longer fetch them and reply with `HTTP 400: wrong type of the web page content`. The current code retries this three times before giving up, which wastes several seconds on each ad without any chance of success.

This PR adds a two-level fallback inside `notify_ad`:

1. If `sendPhoto` with a URL gets a 400 response, the image is downloaded locally and re-uploaded to Telegram as a multipart request (`files={"photo": ...}`). This is the approach suggested in the issue thread — "на стороне бота выгружать картинку и загружать в тг".
2. If the image download itself fails (e.g. Avito returns an error or the URL is unreachable), the notification falls back to a text-only `sendMessage` so the user still receives something.

It also fixes `send_with_retries` to stop retrying non-transient 4xx errors (all 4xx except 429). A 400 is a permanent client error — repeating the same request will always get the same result. The change splits the single `except requests.RequestException` into an `except requests.HTTPError` guard (which re-raises 4xx immediately) followed by the existing `except requests.RequestException` for network-level errors.

I might be wrong about some edge cases here — for example, other Telegram 400s unrelated to image fetching would also trigger the byte-download path, though in practice those should be rare with the current message formatting. If the direction doesn't fit, no problem at all; happy to adjust or close.

---

*This contribution was written with AI assistance and reviewed before submission.*