### PR TITLE
feat: автоудаление старых лог-файлов и сжатие ротированных логов (fixes #274)

### DIFF
--- a/AvitoParser.py
+++ b/AvitoParser.py
@@ -13,6 +13,7 @@ from lang import *
 from load_config import save_avito_config, load_avito_config
 from parser_cls import AvitoParse
 from utils import prompt_user_login
+from utils.log_cleanup import clean_old_logs
 from version import VERSION
 
 
@@ -132,6 +133,7 @@ def main(page: ft.Page):
         page.update()
 
     def logger_console_init():
+        clean_old_logs("logs", max_age_days=5, max_files=10)
         logger.add(logger_console_widget, format="{time:HH:mm:ss} - {message}")
 
     def logger_console_widget(message):

--- a/config.toml
+++ b/config.toml
@@ -36,3 +36,5 @@ tg_only_text = false
 retry_delay = 5
 timeout = 20
 block_threshold = 3
+log_retention_days = 5
+log_max_files = 10

--- a/dto.py
+++ b/dto.py
@@ -56,4 +56,6 @@ class AvitoConfig:
     retry_delay: int = 5
     timeout: int = 20
     block_threshold: int = 3
+    log_retention_days: int = 5
+    log_max_files: int = 10
 

--- a/parser_cls.py
+++ b/parser_cls.py
@@ -23,12 +23,15 @@ from parser.http.client import HttpClient
 from parser.proxies.proxy_factory import build_proxy
 from parser.url_converter import AvitoUrlConverter
 from utils.parse_phone import ParsePhone
+from utils.log_cleanup import clean_old_logs
 from version import VERSION
 from lang import SPFA_PROXY_REQUIRED
 
 DEBUG_MODE = False
 
-logger.add("logs/app.log", rotation="5 MB", retention="5 days", level="DEBUG")
+# Очистка устаревших логов перед добавлением хендлера (Issue #274)
+clean_old_logs("logs", max_age_days=5, max_files=10)
+logger.add("logs/app.log", rotation="5 MB", retention="5 days", compression="zip", level="DEBUG")
 
 
 class AvitoParse:
@@ -38,6 +41,10 @@ class AvitoParse:
             stop_event=None
     ):
         self.config = config
+        retention_days = getattr(self.config, "log_retention_days", 5)
+        max_files = getattr(self.config, "log_max_files", 10)
+        clean_old_logs("logs", max_age_days=retention_days, max_files=max_files)
+
         self.proxy = build_proxy(self.config)
         self.cookies_provider = build_cookies_provider(config=config, proxy=self.proxy)
         self.db_handler = SQLiteDBHandler()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_log_cleanup.py
+++ b/tests/test_log_cleanup.py
@@ -1,0 +1,81 @@
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from utils.log_cleanup import clean_old_logs
+
+
+def test_clean_old_logs_removes_old_files():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dir_path = Path(tmp_dir)
+        old_log = dir_path / "app.old.log"
+        fresh_log = dir_path / "app.log"
+
+        old_log.write_text("old logs")
+        fresh_log.write_text("fresh logs")
+
+        # Set mtime of old_log to 10 days ago
+        ten_days_ago = time.time() - (10 * 86400)
+        os.utime(old_log, (ten_days_ago, ten_days_ago))
+
+        removed = clean_old_logs(dir_path, max_age_days=5, max_files=10)
+
+        assert len(removed) == 1
+        assert old_log.name in [f.name for f in removed]
+        assert not old_log.exists()
+        assert fresh_log.exists()
+
+
+def test_clean_old_logs_prunes_excess_files():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dir_path = Path(tmp_dir)
+        now = time.time()
+
+        # Create 8 files, each 1 hour apart
+        files = []
+        for i in range(8):
+            f = dir_path / f"app.{i}.log"
+            f.write_text(f"log {i}")
+            file_time = now - (i * 3600)
+            os.utime(f, (file_time, file_time))
+            files.append(f)
+
+        # Retain at most 3 files
+        removed = clean_old_logs(dir_path, max_age_days=30, max_files=3)
+
+        assert len(removed) == 5
+        remaining = list(dir_path.glob("*.log"))
+        assert len(remaining) == 3
+        # The 3 newest files should be app.0.log, app.1.log, app.2.log
+        remaining_names = {f.name for f in remaining}
+        assert remaining_names == {"app.0.log", "app.1.log", "app.2.log"}
+
+
+def test_clean_old_logs_handles_missing_dir():
+    result = clean_old_logs("non_existent_logs_dir_xyz_123")
+    assert result == []
+
+
+def test_clean_old_logs_preserves_non_log_files():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dir_path = Path(tmp_dir)
+        data_json = dir_path / "data.json"
+        config_toml = dir_path / "config.toml"
+        old_log = dir_path / "app.2025-01-01.log"
+
+        data_json.write_text("{}")
+        config_toml.write_text("")
+        old_log.write_text("old log")
+
+        ten_days_ago = time.time() - (10 * 86400)
+        os.utime(data_json, (ten_days_ago, ten_days_ago))
+        os.utime(config_toml, (ten_days_ago, ten_days_ago))
+        os.utime(old_log, (ten_days_ago, ten_days_ago))
+
+        removed = clean_old_logs(dir_path, max_age_days=5, max_files=1)
+
+        assert len(removed) == 1
+        assert removed[0].name == "app.2025-01-01.log"
+        assert data_json.exists()
+        assert config_toml.exists()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils package

--- a/utils/log_cleanup.py
+++ b/utils/log_cleanup.py
@@ -1,0 +1,67 @@
+"""
+Утилита для управления ротацией и автоматической очисткой старых лог-файлов.
+Решает проблему накопления логов на диске (Issue #274).
+"""
+import time
+from pathlib import Path
+from loguru import logger
+
+
+def clean_old_logs(
+    log_dir: Path | str = "logs",
+    max_age_days: int = 5,
+    max_files: int = 10,
+) -> list[Path]:
+    """
+    Удаляет устаревшие и избыточные лог-файлы из директории логов.
+
+    :param log_dir: путь к папке с логами (по умолчанию 'logs')
+    :param max_age_days: максимальный возраст файлов в днях (файлы старше удаляются)
+    :param max_files: максимальное количество сохраняемых файлов логов
+    :return: список путей успешно удаленных файлов
+    """
+    log_path = Path(log_dir)
+    if not log_path.exists() or not log_path.is_dir():
+        return []
+
+    removed_files: list[Path] = []
+    now = time.time()
+    max_age_seconds = max_age_days * 86400
+
+    # Находим все файлы логов и их архивы (.log, .zip, .gz, .tar и т.д.)
+    log_files = [
+        f for f in log_path.iterdir()
+        if f.is_file() and (".log" in f.name or f.suffix in {".log", ".zip", ".gz"})
+    ]
+
+    # 1. Удаляем файлы, превысившие максимальный возраст
+    remaining_files: list[Path] = []
+    for file in log_files:
+        try:
+            file_mtime = file.stat().st_mtime
+            if (now - file_mtime) > max_age_seconds:
+                file.unlink(missing_ok=True)
+                removed_files.append(file)
+                logger.debug(f"Удален устаревший лог-файл: {file.name}")
+            else:
+                remaining_files.append(file)
+        except OSError as err:
+            logger.warning(f"Не удалось проверить/удалить лог-файл {file.name}: {err}")
+            remaining_files.append(file)
+
+    # 2. Если оставшихся файлов больше max_files, удаляем самые старые
+    if len(remaining_files) > max_files:
+        remaining_files.sort(key=lambda f: f.stat().st_mtime if f.exists() else 0)
+        excess_count = len(remaining_files) - max_files
+        for file in remaining_files[:excess_count]:
+            try:
+                file.unlink(missing_ok=True)
+                removed_files.append(file)
+                logger.debug(f"Удален избыточный лог-файл по лимиту: {file.name}")
+            except OSError as err:
+                logger.warning(f"Не удалось удалить лог-файл {file.name}: {err}")
+
+    if removed_files:
+        logger.info(f"Очистка логов: удалено {len(removed_files)} старых/избыточных файлов")
+
+    return removed_files


### PR DESCRIPTION
### Автоматическая очистка устаревших лог-файлов и сжатие логов (Fixes #274)

Реализовано решение проблемы переполнения постоянной памяти на серверах и VPS из-за накопления лог-файлов.

#### В чем была проблема (#274):
Ротация Loguru (`retention="5 days"`) срабатывает только в рамках одного непрерывного процесса при превышении размера файла (`5 MB`). При частых перезапусках парсера, сбоях или аварийных остановках старые логи прошлых сессий никогда не удалялись автоматически и занимали гигабайты памяти на диске.

#### Что сделано:
1. **Автоматическая очистка при старте (`utils/log_cleanup.py`)**:
   - Реализована функция `clean_old_logs()`, которая сканирует директорию логов при запуске приложения (`parser_cls.py` и `AvitoParser.py`).
   - Удаляет файлы старше `log_retention_days` (по умолчанию 5 дней).
   - Ограничивает общее число файлов логов лимитом `log_max_files` (по умолчанию 10), удаляя самые старые при превышении.
   - Безопасно обрабатывает заблокированные системой файлы без прерывания работы парсера.
2. **Сжатие ротированных логов**:
   - Для хендлера `logger.add("logs/app.log")` включен параметр `compression="zip"`. Текстовые логи сжимаются более чем на 90%, что практически сводит к нулю потребление дискового пространства архивными файлами.
3. **Настройки в `config.toml` и `dto.py`**:
   - Добавлены параметры `log_retention_days = 5` и `log_max_files = 10` в `AvitoConfig`.
4. **Тестирование (`tests/test_log_cleanup.py`)**:
   - Написаны модульные тесты: проверка удаления старых файлов по возрасту, проверка ограничения по общему количеству, обработка отсутствующей папки и сохранение не связанных с логами файлов.
   - Все 4 теста успешно проходят.
