### PR TITLE
feat: парсинг полного описания товара со страницы объявления (fixes #305)

### DIFF
--- a/AvitoParser.py
+++ b/AvitoParser.py
@@ -63,6 +63,7 @@ def main(page: ft.Page):
         one_time_start.value = config.one_time_start
         one_file_for_link.value = config.one_file_for_link
         parse_views.value = config.parse_views
+        parse_description.value = getattr(config, "parse_description", False)
         save_xlsx.value = config.save_xlsx
         use_webdriver.value = config.use_webdriver
         use_bypass_api.value = config.use_bypass_api
@@ -110,6 +111,7 @@ def main(page: ft.Page):
             "one_time_start": one_time_start.value,
             "one_file_for_link": one_file_for_link.value,
             "parse_views": parse_views.value,
+            "parse_description": parse_description.value,
             "save_xlsx": save_xlsx.value,
             "use_webdriver": use_webdriver.value,
             "use_bypass_api": use_bypass_api.value,
@@ -548,6 +550,8 @@ def main(page: ft.Page):
                                     tooltip=ONE_FILE_FOR_LINK_HELP)
     parse_views = ft.Checkbox(label="Парсить просмотры", value=False,
                                     tooltip=PARSE_VIEWS_HELP)
+    parse_description = ft.Checkbox(label="Парсить описание полностью", value=False,
+                                    tooltip="Загружает полное описание со страницы товара вместо краткого анонса")
     parse_phone = ft.Checkbox(label="Парсить телефоны", value=False, on_change=check_api_key_exist,
                               tooltip=PARSE_PHONE_HELP)
 
@@ -699,6 +703,7 @@ def main(page: ft.Page):
                     ft.Row([max_count_of_retry, retry_delay, timeout]),
                     ft.Row([one_time_start, one_file_for_link]),
                     ft.Row([parse_views,
+                            parse_description,
                             #parse_phone,
                             save_xlsx]),
                 ]

--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,7 @@ ignore_promotion = false
 one_time_start = false
 one_file_for_link = false
 parse_views = false
+parse_description = false
 save_xlsx = true
 use_webdriver = false
 use_bypass_api = false

--- a/dto.py
+++ b/dto.py
@@ -43,6 +43,7 @@ class AvitoConfig:
     one_time_start: bool = False
     one_file_for_link: bool = False
     parse_views: bool = False
+    parse_description: bool = False
     save_xlsx: bool = True
     use_webdriver: bool = True
     use_bypass_api: bool = False

--- a/parser_cls.py
+++ b/parser_cls.py
@@ -197,6 +197,7 @@ class AvitoParse:
                 filtered_ads = self.filter_ads(ads=ads)
                 self.notifier.notify_many(ads=filtered_ads)
                 filtered_ads = self.parse_views(ads=filtered_ads)
+                filtered_ads = self.parse_description(ads=filtered_ads)
                 filtered_ads = self.parse_phone(ads=filtered_ads)
 
                 if filtered_ads:
@@ -279,10 +280,38 @@ class AvitoParse:
                 if not html_code_full_page:
                     continue
                 ad.total_views, ad.today_views = self._extract_views(html=html_code_full_page)
+                if full_desc := self._extract_description(html=html_code_full_page):
+                    ad.description = full_desc
                 delay = random.uniform(0.1, 0.9)
                 time.sleep(delay)
             except Exception as err:
                 logger.warning(f"Ошибка при парсинге {ad.urlPath}: {err}")
+                continue
+
+        return ads
+
+    def parse_description(self, ads: list[Item]) -> list[Item]:
+        """Парсинг полного описания товара со страницы объявления (Issue #305)."""
+        if not getattr(self.config, "parse_description", False):
+            return ads
+
+        logger.info("Начинаю парсинг полного описания")
+
+        for ad in ads:
+            # Пропускаем, если описание уже получено ранее (например, в parse_views)
+            if ad.description and len(ad.description) > 250 and not ad.description.rstrip().endswith("..."):
+                continue
+
+            try:
+                html_code_full_page = self.fetch_data(url=f"https://www.avito.ru{ad.urlPath}")
+                if not html_code_full_page:
+                    continue
+                if full_desc := self._extract_description(html=html_code_full_page):
+                    ad.description = full_desc
+                delay = random.uniform(0.1, 0.9)
+                time.sleep(delay)
+            except Exception as err:
+                logger.warning(f"Ошибка при парсинге описания {ad.urlPath}: {err}")
                 continue
 
         return ads
@@ -309,6 +338,39 @@ class AvitoParse:
         today = extract_digits(soup.select_one('[data-marker="item-view/today-views"]'))
 
         return total, today
+
+    @staticmethod
+    def _extract_description(html: str) -> str | None:
+        """Извлекает полный текст описания объявления со страницы Avito (Issue #305)."""
+        soup = BeautifulSoup(html, "html.parser")
+
+        # 1. Поиск по data-marker (основной маркер Avito для описания)
+        desc_el = soup.select_one('[data-marker="item-description/text"]')
+        if desc_el:
+            text = desc_el.get_text(separator="\n", strip=True)
+            if text:
+                return text
+
+        # 2. Поиск по микроразметке Schema.org
+        desc_meta = soup.select_one('[itemprop="description"]')
+        if desc_meta:
+            text = desc_meta.get_text(separator="\n", strip=True)
+            if text:
+                return text
+
+        # 3. Поиск в JSON-состоянии страницы
+        try:
+            import html as html_lib
+            for script in soup.select('script[type="mime/invalid"][data-mfe-state="true"]'):
+                if 'sandbox' not in script.text:
+                    data = json.loads(html_lib.unescape(script.text))
+                    item_data = data.get('loaderData', {}).get("data", {}).get("item", {})
+                    if desc := item_data.get("description"):
+                        return desc.strip()
+        except Exception:
+            pass
+
+        return None
 
     @staticmethod
     def _extract_seller_slug(data):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_description_parser.py
+++ b/tests/test_description_parser.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+
+from dto import AvitoConfig
+from models import Item
+from parser_cls import AvitoParse
+
+
+def test_extract_description_from_data_marker():
+    html = """
+    <html>
+        <body>
+            <div data-marker="item-description/text">
+                <p>Игровой компьютер в идеальном состоянии.</p>
+                <p>Характеристики: Ryzen 5 5600, RTX 4060, 32GB RAM.</p>
+                <p>Любые проверки на месте.</p>
+            </div>
+        </body>
+    </html>
+    """
+    desc = AvitoParse._extract_description(html)
+    assert desc is not None
+    assert "Игровой компьютер в идеальном состоянии." in desc
+    assert "Ryzen 5 5600" in desc
+
+
+def test_extract_description_from_schema_org():
+    html = """
+    <html>
+        <body>
+            <div itemprop="description">
+                Продаю ноутбук в хорошем состоянии. Батарею держит 5 часов.
+            </div>
+        </body>
+    </html>
+    """
+    desc = AvitoParse._extract_description(html)
+    assert desc == "Продаю ноутбук в хорошем состоянии. Батарею держит 5 часов."
+
+
+def test_extract_description_from_embedded_json():
+    html = """
+    <html>
+        <head>
+            <script type="mime/invalid" data-mfe-state="true">
+                {"loaderData": {"data": {"item": {"description": "Полное описание товара из JSON loaderData"}}}}
+            </script>
+        </head>
+        <body></body>
+    </html>
+    """
+    desc = AvitoParse._extract_description(html)
+    assert desc == "Полное описание товара из JSON loaderData"
+
+
+def test_extract_description_returns_none_when_empty():
+    html = "<html><body><div>Просто текст без маркеров</div></body></html>"
+    desc = AvitoParse._extract_description(html)
+    assert desc is None
+
+
+def test_parse_description_method_updates_ad():
+    config = AvitoConfig(urls=["https://www.avito.ru/test"], parse_description=True)
+    parser = AvitoParse.__new__(AvitoParse)
+    parser.config = config
+
+    html = """
+    <html><body>
+        <div data-marker="item-description/text">
+            Полный текст описания, который ранее обрезался кнопкой Читать полностью.
+        </div>
+    </body></html>
+    """
+    parser.fetch_data = MagicMock(return_value=html)
+
+    ad = Item(id=1, urlPath="/item_123", description="Короткое описание...")
+    result = parser.parse_description([ad])
+
+    assert len(result) == 1
+    assert result[0].description == "Полный текст описания, который ранее обрезался кнопкой Читать полностью."


### PR DESCRIPTION
### Парсинг полного описания товара со страницы объявления (Fixes #305)

Устранена проблема сохранения обрезанного описания товара (ограниченного анонсом с кнопкой «Читать полностью»).

#### В чем была проблема (#305):
Поисковое API Avito (`items?...`) возвращает в каталоге только краткий текстовый анонс (1-2 предложения с многоточием). Из-за этого в Excel-файл попадала лишь малая часть описания, а ключевые характеристики и подробности товара терялись.

#### Что сделано:
1. **Метод извлечения полного описания `_extract_description()`**:
   - Извлекает полный текст из основного DOM-блока Avito `[data-marker="item-description/text"]`.
   - Поддерживает резервное извлечение из микроразметки Schema.org `[itemprop="description"]`.
   - Поддерживает парсинг из встроенного JSON-состояния страницы (`loaderData.data.item.description`).
   - Сохраняет форматирование абзацев (заменяет переносы строк и теги).
2. **Бесплатное обогащение при `parse_views`**:
   - При включенной опции парсинга просмотров страница товара уже загружается — теперь из нее параллельно извлекается и сохраняется в `ad.description` полное описание без дополнительных HTTP-запросов.
3. **Отдельная опция `parse_description`**:
   - Добавлен параметр `parse_description` в `AvitoConfig` и `config.toml`.
   - В графический интерфейс Flet добавлен чекбокс «Парсить описание полностью» для пользователей, которым нужно полное описание даже без парсинга просмотров.
4. **Тестирование (`tests/test_description_parser.py`)**:
   - 5 модульных тестов, проверяющих все сценарии извлечения (data-marker, schema.org, json, пустые страницы и интеграцию в пайплайн).
   - Все 5 тестов успешно проходят.
